### PR TITLE
Memory leak fix (and other minor changes)

### DIFF
--- a/HelperFunction/interface/HelperFunction.h
+++ b/HelperFunction/interface/HelperFunction.h
@@ -94,18 +94,20 @@ class HelperFunction
       void setdebug(int d){debug_= d;};
 
       //ForZ
-      double pterr(reco::Candidate *c, bool isData);
+      double pterr(const reco::Candidate *c, bool isData) const;
 
       //double pterr(pat::Electron electron, bool isData);
       //double pterr(pat::Muon muon, bool isData);
-      double pterr(TLorentzVector fsrPhoton);
+      double pterr(const TLorentzVector& fsrPhoton) const;
 
-      double pterr(reco::GsfElectron* electron, bool isData);
-      double pterr(reco::Muon* muon, bool isData);
+      double pterr(const reco::GsfElectron* electron, bool isData) const;
+      double pterr(const reco::Muon* muon, bool isData) const;
 
-      double masserror(std::vector<TLorentzVector> p4s, std::vector<double> pTErrs);
+      double masserror(const std::vector<TLorentzVector>& p4s, 
+                       const std::vector<double>& pTErrs) const;
 
-      double masserrorFullCov(std::vector<TLorentzVector> p4s, TMatrixDSym covMatrix);
+      double masserrorFullCov(const std::vector<TLorentzVector>& p4s, 
+                              TMatrixDSym& covMatrix) const;
 
       //double masserror(std::vector<TLorentzVector> p4s, )
 

--- a/HelperFunction/src/HelperFunction.cc
+++ b/HelperFunction/src/HelperFunction.cc
@@ -78,7 +78,8 @@ HelperFunction::~HelperFunction()
 // member functions
 //
 
-double HelperFunction:: masserrorFullCov(std::vector<TLorentzVector> p4s, TMatrixDSym covMatrix){
+double HelperFunction:: masserrorFullCov(const std::vector<TLorentzVector>& p4s, 
+                                         TMatrixDSym& covMatrix) const {
 
         int ndim = 3*p4s.size();
         if(debug_) cout<<""<<endl;
@@ -117,7 +118,8 @@ double HelperFunction:: masserrorFullCov(std::vector<TLorentzVector> p4s, TMatri
 }
 
 
-double HelperFunction::masserror( std::vector<TLorentzVector> Lep, std::vector<double> pterr){
+double HelperFunction::masserror( const std::vector<TLorentzVector>& Lep, 
+                                  const std::vector<double>& pterr) const {
         // if(Lep.size()!= pterr.size()!=4) {std::cout<<" Lepsize="<<Lep.size()<<", "<<pterr.size()<<std::endl;}
         TLorentzVector compositeParticle ;
         for(unsigned int i=0; i<Lep.size(); i++){
@@ -144,25 +146,25 @@ double HelperFunction::masserror( std::vector<TLorentzVector> Lep, std::vector<d
 }
 
 
-double HelperFunction::pterr( reco::Candidate *c, bool isData){
+double HelperFunction::pterr( const reco::Candidate *c, bool isData) const {
 
-  reco::GsfElectron *gsf; reco::Muon *mu;
-  reco::PFCandidate *pf;
+  const reco::GsfElectron *gsf; const reco::Muon *mu;
+  const reco::PFCandidate *pf;
 
-  pat::Muon *patmu;
+  const pat::Muon *patmu;
 
   double pterrLep = 0.0;
 
-  if ((gsf = dynamic_cast<reco::GsfElectron *> (&(*c)) ) != 0)
+  if ((gsf = dynamic_cast<const reco::GsfElectron *> (&(*c)) ) != 0)
   {
     pterrLep=pterr(gsf, isData);
   }
-  else if ((mu = dynamic_cast<reco::Muon *> (&(*c)) ) != 0)
+  else if ((mu = dynamic_cast<const reco::Muon *> (&(*c)) ) != 0)
   {
     pterrLep=pterr(mu, isData);
     if(debug_)cout<<"reco pt err is "<<pterrLep<<endl;
 
-    if( (patmu = dynamic_cast<pat::Muon *> (&(*c)) )!=0){
+    if( (patmu = dynamic_cast<const pat::Muon *> (&(*c)) )!=0){
 
      if ( patmu->hasUserFloat("correctedPtError") == true ) {
        if(debug_) cout<<"use userFloat for muon pt err"<<endl;
@@ -172,7 +174,7 @@ double HelperFunction::pterr( reco::Candidate *c, bool isData){
  
     }
   }
-  else if ((pf = dynamic_cast<reco::PFCandidate *> (&(*c)) ) != 0)
+  else if ((pf = dynamic_cast<const reco::PFCandidate *> (&(*c)) ) != 0)
   { 
     pterrLep=pterr(c, isData);
   }
@@ -182,14 +184,14 @@ double HelperFunction::pterr( reco::Candidate *c, bool isData){
 
 }
 
-double HelperFunction::pterr( reco::Muon* mu, bool isData){
+double HelperFunction::pterr( const reco::Muon* mu, bool isData) const {
 
         double pterr = mu->muonBestTrack()->ptError();
 
         return pterr;
 }
 
-double HelperFunction::pterr( reco::GsfElectron * elec, bool isData ){
+double HelperFunction::pterr( const reco::GsfElectron * elec, bool isData ) const {
 
         if(debug_) cout<<"reco:gsfelectron pt err"<<endl; 
 
@@ -224,7 +226,7 @@ double HelperFunction::pterr( reco::GsfElectron * elec, bool isData ){
 }
 
 
-double HelperFunction::pterr(TLorentzVector ph){
+double HelperFunction::pterr(const TLorentzVector& ph) const {
 
          if(debug_) cout<<"perr for pf photon"<<endl;
 

--- a/HelperFunction/src/HelperFunction.cc
+++ b/HelperFunction/src/HelperFunction.cc
@@ -178,6 +178,11 @@ double HelperFunction::pterr( const reco::Candidate *c, bool isData) const {
   { 
     pterrLep=pterr(c, isData);
   }
+  else
+    throw cms::Exception("InvalidCast") << "KinZFitter only takes particles "
+                                        << "whose pointers can be cast to "
+                                        << "electrons, muons, or PFCandidates"
+                                        << std::endl;
 
 
   return pterrLep;

--- a/KinZfitter/interface/KinZfitter.h
+++ b/KinZfitter/interface/KinZfitter.h
@@ -60,7 +60,11 @@ public:
 
 	/// Kinematic fit of lepton momenta
         /// HelperFunction class to calcluate per lepton(+photon) pT error
-        void Setup(std::vector< reco::Candidate* > selectedLeptons, std::map<unsigned int, TLorentzVector> selectedFsrPhotons);
+        void Setup(const std::vector< const reco::Candidate* >& selectedLeptons, 
+                   const std::map<unsigned int, TLorentzVector>& selectedFsrPhotons);
+        /// For backwards compatibility
+        void Setup(const std::vector< reco::Candidate* >& selectedLeptons, 
+                   const std::map<unsigned int, TLorentzVector>& selectedFsrPhotons);
 
         ///
         void KinRefitZ();
@@ -70,17 +74,17 @@ public:
                         double l3, double l4, double lph3, double lph4);
 
         // result wrappers
-        double GetRefitM4l();
-        double GetM4l();
-        double GetRefitMZ1();
-        double GetRefitMZ2();
-        double GetMZ1();
-        double GetMZ2();
+        double GetRefitM4l() const;
+        double GetM4l() const;
+        double GetRefitMZ1() const;
+        double GetRefitMZ2() const;
+        double GetMZ1() const;
+        double GetMZ2() const;
 
-        double GetMZ1Err();
-        double GetRefitM4lErr();
-        double GetM4lErr();
-        double GetRefitM4lErrFullCov();
+        double GetMZ1Err() const;
+        double GetRefitM4lErr() const;
+        double GetM4lErr() const;
+        double GetRefitM4lErrFullCov() const;
 
         // cov matrix change for spherical coordinate to Cartisean coordinates
 
@@ -99,8 +103,8 @@ public:
         TMatrixDSym GetRefitZZOFBigCov();
 */
 
-        std::vector<TLorentzVector> GetRefitP4s();
-        std::vector<TLorentzVector> GetP4s();
+        std::vector<TLorentzVector> GetRefitP4s() const;
+        std::vector<TLorentzVector> GetP4s() const;
 
         ////////////////
 
@@ -147,11 +151,12 @@ private:
         /// HelperFunction class to calcluate per lepton(+photon) pT error
         HelperFunction * helperFunc_;
 
-        void initZs(std::vector< reco::Candidate* > selectedLeptons, std::map<unsigned int, TLorentzVector> selectedFsrPhoton);
+        void initZs(const std::vector< const reco::Candidate* >& selectedLeptons, 
+                    const std::map<unsigned int, TLorentzVector>& selectedFsrPhoton);
      
         void SetFitInput(FitInput &input,
-                         vector<TLorentzVector> ZLep, vector<double> ZLepErr,
-                         vector<TLorentzVector> ZGamma, vector<double> ZGammaErr);
+                         const vector<TLorentzVector>& ZLep, const vector<double>& ZLepErr,
+                         const vector<TLorentzVector>& ZGamma, const vector<double>& ZGammaErr);
 
         void SetFitOutput(FitInput &input, FitOutput &output,
                           double &l1, double &l2, double &lph1, double &lph2,
@@ -170,7 +175,7 @@ private:
                         vector<TLorentzVector> &Z2Gamma, vector<double> &Z2GammaErr,
                         vector<int> &Z1id, vector<int> &Z2id);
 
-        bool IsFourEFourMu(vector<int> &Z1id, vector<int> &Z2id);
+        bool IsFourEFourMu(const vector<int> &Z1id, const vector<int> &Z2id) const;
         /// lepton ids for Z1 Z2
         std::vector<int> idsZ1_, idsZ2_;
         /// lepton ids that fsr photon associated to

--- a/KinZfitter/interface/KinZfitter.h
+++ b/KinZfitter/interface/KinZfitter.h
@@ -57,6 +57,7 @@ class KinZfitter {
 public:
 	
         KinZfitter(bool isData);
+        ~KinZfitter();
 
 	/// Kinematic fit of lepton momenta
         /// HelperFunction class to calcluate per lepton(+photon) pT error

--- a/KinZfitter/src/KinZfitter.cpp
+++ b/KinZfitter/src/KinZfitter.cpp
@@ -34,7 +34,8 @@ KinZfitter::KinZfitter(bool isData)
 }
 
 
-void KinZfitter::Setup(std::vector< reco::Candidate* > selectedLeptons, std::map<unsigned int, TLorentzVector> selectedFsrPhotons){
+void KinZfitter::Setup(const std::vector< const reco::Candidate* >& selectedLeptons, 
+                       const std::map<unsigned int, TLorentzVector>& selectedFsrPhotons){
 
      // reset everything for each event
      idsZ1_.clear(); idsZ2_.clear();      
@@ -93,11 +94,21 @@ void KinZfitter::Setup(std::vector< reco::Candidate* > selectedLeptons, std::map
 }
 
 
+void KinZfitter::Setup(const std::vector< reco::Candidate* >& selectedLeptons, 
+                       const std::map<unsigned int, TLorentzVector>& selectedFsrPhotons){
+  
+  // copy whole vector to make each element const separately
+  std::vector<const reco::Candidate*> temp(selectedLeptons.begin(), 
+                                           selectedLeptons.end());
+  Setup(temp, selectedFsrPhotons);
+}
+
 
 ///----------------------------------------------------------------------------------------------
 ///----------------------------------------------------------------------------------------------
 
-void KinZfitter::initZs(std::vector< reco::Candidate* > selectedLeptons, std::map<unsigned int, TLorentzVector> selectedFsrPhotons){
+void KinZfitter::initZs(const std::vector< const reco::Candidate* >& selectedLeptons, 
+                        const std::map<unsigned int, TLorentzVector>& selectedFsrPhotons){
 
         if(debug_) cout<<"init leptons"<<endl;
 
@@ -105,7 +116,7 @@ void KinZfitter::initZs(std::vector< reco::Candidate* > selectedLeptons, std::ma
          {
             double pTerr = 0; TLorentzVector p4;
 
-            reco::Candidate * c = selectedLeptons[il];              
+            const reco::Candidate * c = selectedLeptons[il];              
             pTerr = helperFunc_->pterr(c ,  isData_);
             p4.SetPxPyPzE(c->px(),c->py(),c->pz(),c->energy());  
             int pdgId = c->pdgId();
@@ -132,8 +143,8 @@ void KinZfitter::initZs(std::vector< reco::Candidate* > selectedLeptons, std::ma
         for(unsigned int ifsr = 0; ifsr<4; ifsr++)
          {
 
-            TLorentzVector p4 = selectedFsrPhotons[ifsr];
-            if(selectedFsrPhotons[ifsr].Pt()==0) continue;
+            if(selectedFsrPhotons.find(ifsr) == selectedFsrPhotons.end()) continue;
+            TLorentzVector p4 = selectedFsrPhotons.at(ifsr);
 
             if(debug_) cout<<"ifsr "<<ifsr<<endl;
 
@@ -235,7 +246,7 @@ void KinZfitter::SetZResult(double l1, double l2, double lph1, double lph2,
   if(debug_) cout<<"end set Z1 result"<<endl;
 }
 
-double KinZfitter::GetM4l()
+double KinZfitter::GetM4l() const
 {
 
   vector<TLorentzVector> p4s = GetP4s();
@@ -250,7 +261,7 @@ double KinZfitter::GetM4l()
 }
 
 
-double KinZfitter::GetRefitM4l()
+double KinZfitter::GetRefitM4l() const
 {
 
   vector<TLorentzVector> p4s = GetRefitP4s();
@@ -264,7 +275,7 @@ double KinZfitter::GetRefitM4l()
 
 }
 
-double KinZfitter::GetRefitMZ1()
+double KinZfitter::GetRefitMZ1() const
 {
 
   vector<TLorentzVector> p4s = GetRefitP4s();
@@ -276,7 +287,7 @@ double KinZfitter::GetRefitMZ1()
   return pZ1.M();
 
 }
-double KinZfitter::GetRefitMZ2()
+double KinZfitter::GetRefitMZ2() const
 {
 
   vector<TLorentzVector> p4s = GetRefitP4s();
@@ -289,7 +300,7 @@ double KinZfitter::GetRefitMZ2()
 
 }
 
-double KinZfitter::GetMZ1()
+double KinZfitter::GetMZ1() const
 {
 
   vector<TLorentzVector> p4s = GetP4s();
@@ -301,7 +312,7 @@ double KinZfitter::GetMZ1()
   return pZ1.M();
 
 }
-double KinZfitter::GetMZ2()
+double KinZfitter::GetMZ2() const
 {
 
   vector<TLorentzVector> p4s = GetP4s();
@@ -315,7 +326,7 @@ double KinZfitter::GetMZ2()
 }
 
 
-double KinZfitter::GetRefitM4lErr()
+double KinZfitter::GetRefitM4lErr() const
 {
 
   vector<TLorentzVector> p4s;
@@ -349,7 +360,7 @@ double KinZfitter::GetRefitM4lErr()
 
 }
 
-double KinZfitter::GetRefitM4lErrFullCov()
+double KinZfitter::GetRefitM4lErrFullCov() const
 {
 
 
@@ -460,7 +471,7 @@ double KinZfitter::GetRefitM4lErrFullCov()
   
 }
 
-double KinZfitter::GetM4lErr()
+double KinZfitter::GetM4lErr() const
 {
   
   vector<TLorentzVector> p4s;
@@ -490,7 +501,7 @@ double KinZfitter::GetM4lErr()
 
 }
 
-double KinZfitter::GetMZ1Err()
+double KinZfitter::GetMZ1Err() const
 {
 
   vector<TLorentzVector> p4s;
@@ -511,7 +522,7 @@ double KinZfitter::GetMZ1Err()
 }
 
 
-vector<TLorentzVector> KinZfitter::GetRefitP4s()
+vector<TLorentzVector> KinZfitter::GetRefitP4s() const
 {
 
   TLorentzVector Z1_1 = p4sZ1REFIT_[0]; TLorentzVector Z1_2 = p4sZ1REFIT_[1];
@@ -547,7 +558,7 @@ vector<TLorentzVector> KinZfitter::GetRefitP4s()
 
 }
 
-vector<TLorentzVector> KinZfitter::GetP4s()
+vector<TLorentzVector> KinZfitter::GetP4s() const
 {
 
   TLorentzVector Z1_1 = p4sZ1_[0]; TLorentzVector Z1_2 = p4sZ1_[1];
@@ -612,13 +623,12 @@ void KinZfitter::KinRefitZ()
             if (fourEfourMu) {//4e,4mu, do reshuffle
 
                RepairZ1Z2(p4sZ1_, pTerrsZ1_, p4sZ1ph_, pTerrsZ1ph_, p4sZ2_, pTerrsZ2_, p4sZ2ph_, pTerrsZ2ph_, idsZ1_, idsZ2_);
-
+               
                }
        
             SetFitInput(fitInput1, p4sZ1_, pTerrsZ1_, p4sZ1ph_, pTerrsZ1ph_);
             Driver(fitInput1, fitOutput1);
             SetFitOutput(fitInput1, fitOutput1, l1, l2, lph1, lph2, pTerrsZ1REFIT_, pTerrsZ1phREFIT_, covMatrixZ1_);
-
             SetFitInput(fitInput2, p4sZ2_, pTerrsZ2_, p4sZ2ph_, pTerrsZ2ph_);
             Driver(fitInput2, fitOutput2);
             SetFitOutput(fitInput2, fitOutput2, l3, l4, lph3, lph4, pTerrsZ2REFIT_, pTerrsZ2phREFIT_, covMatrixZ2_);
@@ -641,8 +651,8 @@ void  KinZfitter::Driver(KinZfitter::FitInput &input, KinZfitter::FitOutput &out
 
 
 void  KinZfitter::SetFitInput(KinZfitter::FitInput &input, 
-                              vector<TLorentzVector> ZLep, vector<double> ZLepErr,
-                              vector<TLorentzVector> ZGamma, vector<double> ZGammaErr) {
+                              const vector<TLorentzVector>& ZLep, const vector<double>& ZLepErr,
+                              const vector<TLorentzVector>& ZGamma, const vector<double>& ZGammaErr) {
 
       TLorentzVector lep1 = ZLep[0]; TLorentzVector lep2 = ZLep[1];
 
@@ -914,7 +924,7 @@ void KinZfitter::MakeModel(/*RooWorkspace &w,*/ KinZfitter::FitInput &input, Kin
     delete PDFRelBWxCBxgauss;
 }
 
-bool KinZfitter::IsFourEFourMu(vector<int> &Z1id, vector<int> &Z2id) {
+bool KinZfitter::IsFourEFourMu(const vector<int> &Z1id, const vector<int> &Z2id) const{
 
      bool flag = false;
 


### PR DESCRIPTION
Fix several memory leaks. I don't promise to have found them all, but I got the obvious ones, and my framework's memory use is now much more stable.

Also throws an exception when handed an uncastable particle pointer (instead of segfaulting), and has a bunch of const correctness fixed. Most importantly, it can accept a vector of const particle pointers, which is much more convenient in several frameworks including mine. These changes should be checked for mistakes; I didn't mean to include them in this PR but the memory leak fix is rather urgent.
